### PR TITLE
Bug fix

### DIFF
--- a/lib/rules/mocha-no-only.js
+++ b/lib/rules/mocha-no-only.js
@@ -7,7 +7,7 @@
 module.exports = function(context) {
     return {
         "Identifier": function(node) {
-            if (node.name == 'only') {
+            if (node.name == 'only' && node.parent.object) {
                 var parent_name = node.parent.object.name;
 
                 if(parent_name == 'describe' || parent_name == 'context' ||  parent_name == 'it') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mocha-no-only",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Warns when a Mocha JavaScript test framework keyword 'only' is used",
   "repository" : {
       "type" : "git",


### PR DESCRIPTION
- Edge-case check to ensure parent object exists. When running 
`it.only` in a helper function, outside of the tests, an error would be 
thrown: `TypeError: Cannot read property 'name' of undefined`
- Version bump