### PR TITLE
Add rule for Ethereum smart contract testing

### DIFF
--- a/lib/rules/mocha-no-only.js
+++ b/lib/rules/mocha-no-only.js
@@ -7,6 +7,7 @@
 const mochaKeywords = [
     'describe',
     'context',
+    'contract',
     'it',
     'specify',
     'suite',


### PR DESCRIPTION
[`truffle`](https://truffleframework.com/) is a very popular smart contract development framework in the Ethereum smart contract ecosystem. It allows for testing in JavaScript, integrating with Mocha, but it adds a new `contract` function, [which is sometimes used as a replacement of `describe`](https://truffleframework.com/docs/truffle/testing/writing-tests-in-javascript#use-contract-instead-of-describe-) (semantically they are almost the same).

This PR extends `eslint-mocha-no-only` so that it can also be used when working with `truffle`.