### PR TITLE
Add support for ESLint v9.0.0

### DIFF
--- a/lib/rules/mocha-no-only.js
+++ b/lib/rules/mocha-no-only.js
@@ -16,7 +16,7 @@ const mochaKeywords = [
 
 const isParentAMochaKeyword = parentName => mochaKeywords.some(word => parentName === word);
 
-module.exports = function(context) {
+module.exports.create = function(context) {
     return {
         'Identifier': function(node) {
             if (node.name == 'only' && node.parent.object) {


### PR DESCRIPTION
eslint 9 requires rules to be an object with a `create` method. This is backwards compatible with eslint 8
> `Error while loading rule 'mocha-no-only/mocha-no-only': Rule must be an object with a 'create' method`